### PR TITLE
load config defined namespace

### DIFF
--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -227,9 +227,8 @@ func (a *App) setup() {
 	})
 
 	// Create and push the home view
-	// If using API key auth, skip namespace list and go directly to workflows
-	// (API keys are typically namespace-scoped and can't list all namespaces)
-	if a.provider != nil && a.provider.Config().APIKey != "" {
+	// If a namespace is defined in the connection, skip namespace list and go directly to workflows
+	if a.provider != nil && a.provider.Config().Namespace != "" {
 		wl := NewWorkflowList(a, a.currentNS)
 		a.app.Pages().Push(wl)
 	} else {
@@ -1117,9 +1116,8 @@ func (a *App) SwitchProfile(name string) {
 func (a *App) reinitializeViews() {
 	a.app.Pages().Clear()
 
-	// If using API key auth, skip namespace list and go directly to workflows
-	// (API keys are typically namespace-scoped and can't list all namespaces)
-	if a.provider != nil && a.provider.Config().APIKey != "" {
+	// If a namespace is defined in the connection, skip namespace list and go directly to workflows
+	if a.provider != nil && a.provider.Config().Namespace != "" {
 		wl := NewWorkflowList(a, a.currentNS)
 		a.app.Pages().Push(wl)
 		a.app.SetFocus(wl)

--- a/internal/view/namespace_list.go
+++ b/internal/view/namespace_list.go
@@ -325,18 +325,6 @@ func (nl *NamespaceList) Name() string {
 
 // Start is called when the view becomes active.
 func (nl *NamespaceList) Start() {
-	// If using API key auth, skip namespace list entirely and go to workflows
-	// (API keys are typically namespace-scoped and can't list all namespaces)
-	provider := nl.app.Provider()
-	if provider != nil && provider.Config().APIKey != "" {
-		// Replace this view with workflows for the configured namespace
-		nl.app.JigApp().Pages().Pop() // Remove namespace list from stack
-		wl := NewWorkflowList(nl.app, provider.Config().Namespace)
-		nl.app.JigApp().Pages().Push(wl)
-		nl.app.JigApp().SetFocus(wl)
-		return
-	}
-
 	bindings := input.NewKeyBindings().
 		OnRune('/', func(e *tcell.EventKey) bool {
 			nl.ShowSearch()


### PR DESCRIPTION
Load the configured namespace on start skipping the namespace list


Fixes #10 

## Slop
This pull request refines the app's logic for skipping the namespace selection step and going directly to the workflows view. Previously, this behavior was triggered when an API key was used (since API keys are often namespace-scoped). Now, the logic is updated to check if a specific namespace is defined in the connection configuration, making the flow more accurate and flexible.

Key changes:

**Navigation logic updates:**

* Updated the condition in `internal/view/app.go` to skip the namespace list and go directly to the workflows view if a namespace is defined in the connection config, rather than just checking for API key authentication. [[1]](diffhunk://#diff-d7170117325094b37d6686b3d1475d9894de729afbc64f73ac540022149061ecL230-R231) [[2]](diffhunk://#diff-d7170117325094b37d6686b3d1475d9894de729afbc64f73ac540022149061ecL1120-R1120)

**Code cleanup:**

* Removed redundant logic from `internal/view/namespace_list.go` that previously checked for API key authentication to skip the namespace list, as this is now handled in a single place.