### PR TITLE
fix deadlock on workflow start toast

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/atterpac/jig v0.1.3
+	github.com/atterpac/jig v0.1.5
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/gdamore/tcell/v2 v2.13.4
 	github.com/rivo/tview v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/atterpac/jig v0.1.5 h1:3X+hIjjzcMVzzsvZkfOjLR+6sL3B/BRi+WsMBlX0eV4=
+github.com/atterpac/jig v0.1.5/go.mod h1:ojogBHb2T6CyWl+6w49GopfddK3IvaWgOBuPs+KwV58=
 github.com/creativeprojects/go-selfupdate v1.5.2 h1:3KR3JLrq70oplb9yZzbmJ89qRP78D1AN/9u+l3k0LJ4=
 github.com/creativeprojects/go-selfupdate v1.5.2/go.mod h1:BCOuwIl1dRRCmPNRPH0amULeZqayhKyY2mH/h4va7Dk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/view/workflow_list_start.go
+++ b/internal/view/workflow_list_start.go
@@ -101,7 +101,7 @@ func executeStartWorkflow(app *App, workflowID, workflowType, taskQueue, input s
 				return
 			}
 
-			app.ShowToastSuccess(fmt.Sprintf("Workflow %s started", workflowID))
+			app.ToastSuccess(fmt.Sprintf("Workflow %s started", workflowID))
 			app.NavigateToWorkflowDetail(workflowID, runID)
 		})
 	}()


### PR DESCRIPTION
This pull request includes a dependency update and a minor refactor to improve naming consistency in the codebase. The most important changes are:

Dependency updates:

* Upgraded the `github.com/atterpac/jig` dependency from version `v0.1.3` to `v0.1.5` in `go.mod`.

Code quality improvements:

* Renamed the `ShowToastSuccess` method to `ToastSuccess` in `internal/view/workflow_list_start.go` to ensure consistent naming conventions.