### PR TITLE
Atterpac/feature request/24/grpc meta

### DIFF
--- a/cmd/tempo/tempo.go
+++ b/cmd/tempo/tempo.go
@@ -104,6 +104,7 @@ func main() {
 		TLSServerName: profileConfig.TLS.ServerName,
 		TLSSkipVerify: profileConfig.TLS.SkipVerify,
 		APIKey:        profileConfig.APIKey,
+		GRPCMeta:      profileConfig.GRPCMeta,
 	}
 
 	// CLI flags override profile settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,19 +43,27 @@ type ConnectionConfig struct {
 	Namespace string                    `yaml:"namespace"`
 	TLS       TLSConfig                 `yaml:"tls,omitempty"`
 	APIKey    string                    `yaml:"api_key,omitempty"` // For Temporal Cloud API key authentication
+	GRPCMeta  map[string]string         `yaml:"grpc_meta,omitempty"` // Custom gRPC metadata headers (KEY=VALUE pairs)
 	Commands  map[string]CommandConfig  `yaml:"commands,omitempty"`
 }
 
 // ExpandEnv expands environment variables in sensitive fields.
 // Supports ${VAR}, $VAR, and ${VAR:-default} syntax.
 func (c ConnectionConfig) ExpandEnv() ConnectionConfig {
-	return ConnectionConfig{
+	expanded := ConnectionConfig{
 		Address:   c.Address,
 		Namespace: c.Namespace,
 		TLS:       c.TLS,
 		APIKey:    expandEnvVar(c.APIKey),
 		Commands:  c.Commands,
 	}
+	if len(c.GRPCMeta) > 0 {
+		expanded.GRPCMeta = make(map[string]string, len(c.GRPCMeta))
+		for k, v := range c.GRPCMeta {
+			expanded.GRPCMeta[k] = expandEnvVar(v)
+		}
+	}
+	return expanded
 }
 
 // expandEnvVar expands environment variable references in a string.

--- a/internal/temporal/client.go
+++ b/internal/temporal/client.go
@@ -70,6 +70,16 @@ func initLogFile() {
 	sdkLogger = &fileLogger{logger: log.New(f, "", log.Ldate|log.Ltime)}
 }
 
+// staticHeadersProvider implements the Temporal SDK HeadersProvider interface,
+// returning a fixed set of gRPC metadata headers on every outgoing request.
+type staticHeadersProvider struct {
+	headers map[string]string
+}
+
+func (p *staticHeadersProvider) GetHeaders(_ context.Context) (map[string]string, error) {
+	return p.headers, nil
+}
+
 // Client implements the Provider interface using the Temporal SDK.
 type Client struct {
 	client    client.Client
@@ -102,6 +112,11 @@ func NewClient(ctx context.Context, connConfig ConnectionConfig) (*Client, error
 			return nil, fmt.Errorf("failed to configure TLS: %w", err)
 		}
 		opts.ConnectionOptions.TLS = tlsConfig
+	}
+
+	// Attach custom gRPC metadata headers if configured
+	if len(connConfig.GRPCMeta) > 0 {
+		opts.HeadersProvider = &staticHeadersProvider{headers: connConfig.GRPCMeta}
 	}
 
 	c, err := client.DialContext(ctx, opts)
@@ -244,6 +259,11 @@ func (c *Client) reconnectWithConfig(ctx context.Context, connConfig ConnectionC
 			return fmt.Errorf("failed to configure TLS: %w", err)
 		}
 		opts.ConnectionOptions.TLS = tlsConfig
+	}
+
+	// Attach custom gRPC metadata headers if configured
+	if len(connConfig.GRPCMeta) > 0 {
+		opts.HeadersProvider = &staticHeadersProvider{headers: connConfig.GRPCMeta}
 	}
 
 	newClient, err := client.DialContext(ctx, opts)

--- a/internal/temporal/provider.go
+++ b/internal/temporal/provider.go
@@ -294,7 +294,8 @@ type ConnectionConfig struct {
 	TLSCAPath     string
 	TLSServerName string
 	TLSSkipVerify bool
-	APIKey        string // For Temporal Cloud API key authentication
+	APIKey        string            // For Temporal Cloud API key authentication
+	GRPCMeta      map[string]string // Custom gRPC metadata headers attached to every request
 }
 
 // DefaultConnectionConfig returns default connection settings.

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -1173,6 +1173,7 @@ func (a *App) SwitchProfile(name string) {
 		TLSServerName: profileCfg.TLS.ServerName,
 		TLSSkipVerify: profileCfg.TLS.SkipVerify,
 		APIKey:        profileCfg.APIKey,
+		GRPCMeta:      profileCfg.GRPCMeta,
 	}
 
 	// Stop current views

--- a/internal/view/modals.go
+++ b/internal/view/modals.go
@@ -549,6 +549,8 @@ func (f *ProfileForm) buildForm(name string, cfg config.ConnectionConfig, isEdit
 				ServerName: values["tlsServerName"].(string),
 				SkipVerify: skipVerify,
 			},
+			APIKey:   cfg.APIKey,
+			GRPCMeta: cfg.GRPCMeta,
 		}
 
 		if f.onSave != nil {


### PR DESCRIPTION
Adds grpc-meta config options that gets appended to all temporal queries supports expanded queries and defaults 
`{$ENV_VAR:-defaultValue}`

```
   prod-profile: 
      address: myaddr.temporal:7233
      grpc_meta:
        some-header-value: $EXPANDED_ENV
```
  
Solves #24 

## Slop
This pull request introduces support for attaching custom gRPC metadata headers to Temporal client requests. The main change is the addition of a new `GRPCMeta` field to the connection configuration, allowing users to specify arbitrary key-value pairs that will be sent as headers with every gRPC request. The implementation ensures these headers are respected throughout client creation, reconnection, and configuration flows.

**Support for custom gRPC metadata headers:**

* Added a `GRPCMeta` field (map of string to string) to the `ConnectionConfig` struct in `config.go`, `provider.go`, and ensured it is passed through the application's connection logic and UI forms. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR46-R66) [[2]](diffhunk://#diff-badee0dc1296d9b8d2dde588450e2066db16ddcb9a88b9a92ba4c2c8cd8835ffR298) [[3]](diffhunk://#diff-6c30bf4a8287419ed8e7aa6349195282156dc05515e38d36c7d9c7d92603ad08R552-R553) [[4]](diffhunk://#diff-4df8f00ab2ee520392907e4212fea0207b9f84c439d37797d62da99f47667c12R107) [[5]](diffhunk://#diff-d7170117325094b37d6686b3d1475d9894de729afbc64f73ac540022149061ecR1176)
* Updated the `ExpandEnv` method in `ConnectionConfig` to expand environment variables within the `GRPCMeta` values.
* Implemented a `staticHeadersProvider` type that satisfies the Temporal SDK `HeadersProvider` interface, returning the configured `GRPCMeta` headers on every request.
* Modified both the client initialization (`NewClient`) and reconnection logic (`reconnectWithConfig`) to set the `HeadersProvider` when `GRPCMeta` is present in the configuration. [[1]](diffhunk://#diff-d96dd1d66b84316bacbf9eb440b31ba30373853cae5c20bd94ee3b34229374d2R117-R121) [[2]](diffhunk://#diff-d96dd1d66b84316bacbf9eb440b31ba30373853cae5c20bd94ee3b34229374d2R264-R268)