### PR TITLE
Extract and render richer workflow task failure details

### DIFF
--- a/internal/temporal/client.go
+++ b/internal/temporal/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/galaxy-io/tempo/internal/config"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -711,10 +712,7 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
 		attrs := event.GetWorkflowExecutionFailedEventAttributes()
 		if attrs != nil && attrs.GetFailure() != nil {
-			he.Failure = attrs.GetFailure().GetMessage()
-			if attrs.GetFailure().GetStackTrace() != "" {
-				he.Failure += "\n\nStack Trace:\n" + attrs.GetFailure().GetStackTrace()
-			}
+			populateFailureDetails(&he, attrs.GetFailure())
 		}
 
 	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
@@ -765,7 +763,7 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 		if attrs != nil {
 			he.ScheduledEventID = attrs.GetScheduledEventId()
 			if attrs.GetFailure() != nil {
-				he.Failure = attrs.GetFailure().GetMessage()
+				populateFailureDetails(&he, attrs.GetFailure())
 			}
 		}
 
@@ -788,7 +786,7 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 			he.Attempt = attrs.GetAttempt()
 			he.Identity = attrs.GetIdentity()
 			if attrs.GetLastFailure() != nil {
-				he.Failure = attrs.GetLastFailure().GetMessage()
+				populateFailureDetails(&he, attrs.GetLastFailure())
 			}
 		}
 
@@ -809,7 +807,7 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 			he.ScheduledEventID = attrs.GetScheduledEventId()
 			he.StartedEventID = attrs.GetStartedEventId()
 			if attrs.GetFailure() != nil {
-				he.Failure = attrs.GetFailure().GetMessage()
+				populateFailureDetails(&he, attrs.GetFailure())
 			}
 		}
 
@@ -819,7 +817,7 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 			he.ScheduledEventID = attrs.GetScheduledEventId()
 			he.StartedEventID = attrs.GetStartedEventId()
 			if attrs.GetFailure() != nil {
-				he.Failure = attrs.GetFailure().GetMessage()
+				populateFailureDetails(&he, attrs.GetFailure())
 			}
 		}
 
@@ -903,7 +901,7 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 				he.ChildRunID = attrs.GetWorkflowExecution().GetRunId()
 			}
 			if attrs.GetFailure() != nil {
-				he.Failure = attrs.GetFailure().GetMessage()
+				populateFailureDetails(&he, attrs.GetFailure())
 			}
 		}
 
@@ -954,6 +952,39 @@ func extractEnhancedEvent(event *historypb.HistoryEvent) EnhancedHistoryEvent {
 	}
 
 	return he
+}
+
+func populateFailureDetails(event *EnhancedHistoryEvent, failure *failurepb.Failure) {
+	if failure == nil {
+		return
+	}
+	event.Failure = failure.GetMessage()
+	event.FailureSource = failure.GetSource()
+	event.FailureStackTrace = failure.GetStackTrace()
+	event.FailureCause = formatFailureCause(failure.GetCause())
+}
+
+func formatFailureCause(failure *failurepb.Failure) string {
+	if failure == nil {
+		return ""
+	}
+
+	var parts []string
+	for f := failure; f != nil; f = f.GetCause() {
+		var line strings.Builder
+		if f.GetSource() != "" {
+			line.WriteString(f.GetSource())
+			line.WriteString(": ")
+		}
+		line.WriteString(f.GetMessage())
+		if f.GetStackTrace() != "" {
+			line.WriteString("\n")
+			line.WriteString(f.GetStackTrace())
+		}
+		parts = append(parts, line.String())
+	}
+
+	return strings.Join(parts, "\n\nCaused by: ")
 }
 
 // formatEventType cleans up the event type string for display

--- a/internal/temporal/provider.go
+++ b/internal/temporal/provider.go
@@ -239,8 +239,12 @@ type EnhancedHistoryEvent struct {
 	TaskQueue string
 	Identity  string
 	Failure   string
-	Result    string
-	Input     string // Workflow/Activity input
+	// Failure metadata mirrors Temporal failure fields for richer diagnostics.
+	FailureSource     string
+	FailureStackTrace string
+	FailureCause      string
+	Result            string
+	Input             string // Workflow/Activity input
 }
 
 // TaskQueueInfo represents task queue status information.

--- a/internal/view/event_history.go
+++ b/internal/view/event_history.go
@@ -841,10 +841,6 @@ func formatFailureSidePanel(ev *temporal.EnhancedHistoryEvent) string {
 	}
 
 	var result strings.Builder
-	if ev.Failure != "" {
-		formatted := formatSidePanelDetails(ev.Failure)
-		result.WriteString(fmt.Sprintf("\n\n[%s::b]Failure[-:-:-]\n[%s]%s[-]", theme.TagAccent(), theme.TagError(), formatted))
-	}
 	if ev.FailureSource != "" {
 		result.WriteString(fmt.Sprintf("\n\n[%s::b]Source[-:-:-]\n[%s]%s[-]",
 			theme.TagAccent(), theme.TagFg(), tview.Escape(ev.FailureSource)))

--- a/internal/view/event_history.go
+++ b/internal/view/event_history.go
@@ -215,6 +215,10 @@ func (eh *EventHistory) applyFilter(query string) {
 				strings.Contains(strings.ToLower(ev.ActivityType), q) ||
 				strings.Contains(strings.ToLower(ev.TimerID), q) ||
 				strings.Contains(strings.ToLower(ev.ChildWorkflowType), q) ||
+				strings.Contains(strings.ToLower(ev.Failure), q) ||
+				strings.Contains(strings.ToLower(ev.FailureSource), q) ||
+				strings.Contains(strings.ToLower(ev.FailureStackTrace), q) ||
+				strings.Contains(strings.ToLower(ev.FailureCause), q) ||
 				strings.Contains(strings.ToLower(ev.Details), q) {
 				eh.enhancedEvents = append(eh.enhancedEvents, ev)
 			}
@@ -417,7 +421,7 @@ func (eh *EventHistory) updateSidePanelFromList(index int) {
 [%s]%s[-]
 
 [%s::b]Details[-:-:-]
-%s`,
+%s%s`,
 		theme.TagAccent(),
 		theme.TagFg(), ev.ID,
 		theme.TagAccent(),
@@ -426,6 +430,7 @@ func (eh *EventHistory) updateSidePanelFromList(index int) {
 		theme.TagFg(), ev.Time.Format("2006-01-02 15:04:05.000"),
 		theme.TagAccent(),
 		formattedDetails,
+		formatFailureSidePanel(&ev),
 	)
 	eh.sidePanel.SetText(text)
 }
@@ -459,8 +464,7 @@ func (eh *EventHistory) updateSidePanelFromTree(node *temporal.EventTreeNode) {
 			dataStr += fmt.Sprintf("\n\n[%s::b]Result[-:-:-]\n%s", theme.TagAccent(), formatted)
 		}
 		if ev.Failure != "" {
-			formatted := formatSidePanelDetails(ev.Failure)
-			dataStr += fmt.Sprintf("\n\n[%s::b]Failure[-:-:-]\n[%s]%s[-]", theme.TagAccent(), theme.TagError(), formatted)
+			dataStr += formatFailureSidePanel(ev)
 		}
 	}
 
@@ -776,7 +780,7 @@ func (eh *EventHistory) getSelectedEventData() (string, string) {
 			// Get the most relevant event (usually the last one with data)
 			for i := len(node.Events) - 1; i >= 0; i-- {
 				ev := node.Events[i]
-				if ev.Result != "" || ev.Failure != "" || ev.Details != "" {
+				if hasEventData(ev) {
 					return ev.Type, eh.formatEventDataRaw(ev)
 				}
 			}
@@ -806,11 +810,54 @@ func (eh *EventHistory) formatEventDataRaw(ev *temporal.EnhancedHistoryEvent) st
 	if ev.Failure != "" {
 		parts = append(parts, fmt.Sprintf("Failure: %s", prettyPrintJSON(ev.Failure)))
 	}
+	if ev.FailureSource != "" {
+		parts = append(parts, fmt.Sprintf("Source: %s", ev.FailureSource))
+	}
+	if ev.FailureStackTrace != "" {
+		parts = append(parts, fmt.Sprintf("Stack Trace:\n%s", ev.FailureStackTrace))
+	}
+	if ev.FailureCause != "" {
+		parts = append(parts, fmt.Sprintf("Cause:\n%s", ev.FailureCause))
+	}
 
 	if len(parts) == 0 {
 		return ev.Details
 	}
 	return strings.Join(parts, "\n\n")
+}
+
+func hasEventData(ev *temporal.EnhancedHistoryEvent) bool {
+	return ev.Details != "" ||
+		ev.Result != "" ||
+		ev.Failure != "" ||
+		ev.FailureSource != "" ||
+		ev.FailureStackTrace != "" ||
+		ev.FailureCause != ""
+}
+
+func formatFailureSidePanel(ev *temporal.EnhancedHistoryEvent) string {
+	if ev == nil || (ev.Failure == "" && ev.FailureSource == "" && ev.FailureStackTrace == "" && ev.FailureCause == "") {
+		return ""
+	}
+
+	var result strings.Builder
+	if ev.Failure != "" {
+		formatted := formatSidePanelDetails(ev.Failure)
+		result.WriteString(fmt.Sprintf("\n\n[%s::b]Failure[-:-:-]\n[%s]%s[-]", theme.TagAccent(), theme.TagError(), formatted))
+	}
+	if ev.FailureSource != "" {
+		result.WriteString(fmt.Sprintf("\n\n[%s::b]Source[-:-:-]\n[%s]%s[-]",
+			theme.TagAccent(), theme.TagFg(), tview.Escape(ev.FailureSource)))
+	}
+	if ev.FailureStackTrace != "" {
+		result.WriteString(fmt.Sprintf("\n\n[%s::b]Stack Trace[-:-:-]\n[%s]%s[-]",
+			theme.TagAccent(), theme.TagFgDim(), tview.Escape(ev.FailureStackTrace)))
+	}
+	if ev.FailureCause != "" {
+		result.WriteString(fmt.Sprintf("\n\n[%s::b]Cause[-:-:-]\n[%s]%s[-]",
+			theme.TagAccent(), theme.TagFgDim(), tview.Escape(ev.FailureCause)))
+	}
+	return result.String()
 }
 
 // yankEventData copies the selected event's data to clipboard.
@@ -1081,7 +1128,7 @@ func highlightJSONValueLine(line string) string {
 
 // highlightValues highlights JSON values (booleans, null, numbers).
 func highlightValues(s string) string {
-	result := s
+	result := tview.Escape(s)
 	result = strings.ReplaceAll(result, "true", fmt.Sprintf("[%s]true[-]", temporal.StatusCompleted.ColorTag()))
 	result = strings.ReplaceAll(result, "false", fmt.Sprintf("[%s]false[-]", temporal.StatusFailed.ColorTag()))
 	result = strings.ReplaceAll(result, "null", fmt.Sprintf("[%s]null[-]", theme.TagFgDim()))
@@ -1162,7 +1209,7 @@ func highlightJSONLine(line string) string {
 // highlightJSONValue highlights JSON values (strings, numbers, booleans).
 func highlightJSONValue(s string) string {
 	// Replace common JSON patterns with highlighted versions
-	result := s
+	result := tview.Escape(s)
 
 	// Highlight string values (simple approach)
 	// This is a basic implementation - a full JSON parser would be more robust

--- a/internal/view/workflow_detail.go
+++ b/internal/view/workflow_detail.go
@@ -123,6 +123,10 @@ func (wd *WorkflowDetail) applyFilter(query string) {
 				strings.Contains(strings.ToLower(ev.ActivityType), q) ||
 				strings.Contains(strings.ToLower(ev.TimerID), q) ||
 				strings.Contains(strings.ToLower(ev.ChildWorkflowType), q) ||
+				strings.Contains(strings.ToLower(ev.Failure), q) ||
+				strings.Contains(strings.ToLower(ev.FailureSource), q) ||
+				strings.Contains(strings.ToLower(ev.FailureStackTrace), q) ||
+				strings.Contains(strings.ToLower(ev.FailureCause), q) ||
 				strings.Contains(strings.ToLower(ev.Details), q) {
 				wd.events = append(wd.events, ev)
 			}
@@ -369,11 +373,12 @@ func (wd *WorkflowDetail) updateEventDetail(ev temporal.EnhancedHistoryEvent) {
 [%s::b]Type[-:-:-]         [%s]%s %s[-]%s
 [%s::b]Time[-:-:-]         [%s]%s[-]
 
-%s`,
+%s%s`,
 		theme.TagFgDim(), theme.TagFg(), ev.ID,
 		theme.TagFgDim(), colorTag, icon, ev.Type, nameLine,
 		theme.TagFgDim(), theme.TagFg(), ev.Time.Format("2006-01-02 15:04:05.000"),
 		formattedDetails,
+		formatFailureSidePanel(&ev),
 	)
 	wd.eventDetailView.SetText(detailText)
 }
@@ -784,8 +789,8 @@ func truncateStr(s string, maxLen int) string {
 func (wd *WorkflowDetail) showCancelConfirm() {
 	form := components.NewFormBuilder().
 		Text("reason", "Reason (optional)").
-			Value("Cancelled via tempo").
-			Done().
+		Value("Cancelled via tempo").
+		Done().
 		OnSubmit(func(values map[string]any) {
 			reason := values["reason"].(string)
 			wd.closeModal()
@@ -843,9 +848,9 @@ func (wd *WorkflowDetail) executeCancelWorkflow(reason string) {
 func (wd *WorkflowDetail) showTerminateConfirm() {
 	form := components.NewFormBuilder().
 		Text("reason", "Reason (required)").
-			Value("Terminated via tempo").
-			Validate(validators.Required()).
-			Done().
+		Value("Terminated via tempo").
+		Validate(validators.Required()).
+		Done().
 		OnSubmit(func(values map[string]any) {
 			reason := values["reason"].(string)
 			wd.closeModal()
@@ -917,14 +922,14 @@ func (wd *WorkflowDetail) showDeleteConfirm() {
 	workflowID := wd.workflowID
 	form := components.NewFormBuilder().
 		Text("confirm", "Type workflow ID to confirm").
-			Placeholder(workflowID).
-			Validate(validators.Custom(func(value any) error {
-				if s, ok := value.(string); ok && s != workflowID {
-					return fmt.Errorf("must match workflow ID")
-				}
-				return nil
-			})).
-			Done().
+		Placeholder(workflowID).
+		Validate(validators.Custom(func(value any) error {
+			if s, ok := value.(string); ok && s != workflowID {
+				return fmt.Errorf("must match workflow ID")
+			}
+			return nil
+		})).
+		Done().
 		OnSubmit(func(values map[string]any) {
 			confirm := values["confirm"].(string)
 			if confirm != workflowID {
@@ -1003,12 +1008,12 @@ func (wd *WorkflowDetail) executeDeleteWorkflow() {
 func (wd *WorkflowDetail) showSignalInput() {
 	form := components.NewFormBuilder().
 		Text("signalName", "Signal Name").
-			Placeholder("Enter signal name").
-			Validate(validators.Required()).
-			Done().
+		Placeholder("Enter signal name").
+		Validate(validators.Required()).
+		Done().
 		Text("input", "Input (JSON, optional)").
-			Placeholder("{}").
-			Done().
+		Placeholder("{}").
+		Done().
 		OnSubmit(func(values map[string]any) {
 			signalName := values["signalName"].(string)
 			input := values["input"].(string)
@@ -1135,8 +1140,8 @@ func (wd *WorkflowDetail) showResetSelector() {
 func (wd *WorkflowDetail) showQuickResetModal(failurePoint temporal.ResetPoint, allPoints []temporal.ResetPoint) {
 	form := components.NewFormBuilder().
 		Text("reason", "Reason").
-			Value("Reset via tempo").
-			Done().
+		Value("Reset via tempo").
+		Done().
 		OnSubmit(func(values map[string]any) {
 			wd.closeModal()
 			wd.executeResetWorkflow(failurePoint.EventID, values["reason"].(string))
@@ -1245,8 +1250,8 @@ func (wd *WorkflowDetail) showResetConfirm(resetPoint temporal.ResetPoint) {
 	eventID := resetPoint.EventID
 	form := components.NewFormBuilder().
 		Text("reason", "Reason").
-			Value("Reset via tempo").
-			Done().
+		Value("Reset via tempo").
+		Done().
 		OnSubmit(func(values map[string]any) {
 			wd.closeModal()
 			wd.executeResetWorkflow(eventID, values["reason"].(string))
@@ -1360,13 +1365,13 @@ func (wd *WorkflowDetail) closeModal() {
 func (wd *WorkflowDetail) showQueryInput() {
 	form := components.NewFormBuilder().
 		Select("queryType", "Query Type", []string{"__stack_trace", "custom"}).
-			Done().
+		Done().
 		Text("customQuery", "Custom Query Name").
-			Placeholder("Enter custom query name").
-			Done().
+		Placeholder("Enter custom query name").
+		Done().
 		Text("args", "Arguments (JSON, optional)").
-			Placeholder("{}").
-			Done().
+		Placeholder("{}").
+		Done().
 		OnSubmit(func(values map[string]any) {
 			queryType := values["queryType"].(string)
 			if queryType == "custom" {
@@ -1565,7 +1570,35 @@ func (wd *WorkflowDetail) getSelectedEventDetails() (string, string) {
 		return "", ""
 	}
 	ev := wd.events[row]
-	return ev.Type, prettyPrintJSONDetail(ev.Details)
+	return ev.Type, formatWorkflowEventDataRaw(&ev)
+}
+
+func formatWorkflowEventDataRaw(ev *temporal.EnhancedHistoryEvent) string {
+	if ev == nil {
+		return ""
+	}
+
+	var parts []string
+	if ev.Details != "" {
+		parts = append(parts, fmt.Sprintf("Details: %s", prettyPrintJSONDetail(ev.Details)))
+	}
+	if ev.Result != "" {
+		parts = append(parts, fmt.Sprintf("Result: %s", prettyPrintJSONDetail(ev.Result)))
+	}
+	if ev.Failure != "" {
+		parts = append(parts, fmt.Sprintf("Failure: %s", prettyPrintJSONDetail(ev.Failure)))
+	}
+	if ev.FailureSource != "" {
+		parts = append(parts, fmt.Sprintf("Source: %s", ev.FailureSource))
+	}
+	if ev.FailureStackTrace != "" {
+		parts = append(parts, fmt.Sprintf("Stack Trace:\n%s", ev.FailureStackTrace))
+	}
+	if ev.FailureCause != "" {
+		parts = append(parts, fmt.Sprintf("Cause:\n%s", ev.FailureCause))
+	}
+
+	return strings.Join(parts, "\n\n")
 }
 
 // yankEventData copies the selected event's details to clipboard.
@@ -1647,7 +1680,7 @@ func (wd *WorkflowDetail) showEventDetailModal() {
 
 	// Format the details with syntax highlighting
 	formattedDetails := formatEventDetails(ev.Details)
-	fullText := headerText + "\n" + formattedDetails
+	fullText := headerText + "\n" + formattedDetails + formatFailureSidePanel(&ev)
 
 	detailView.SetText(fullText)
 
@@ -1713,9 +1746,9 @@ func (wd *WorkflowDetail) showEventDetailModal() {
 				detailView.ScrollToEnd()
 				return nil
 			case 'y':
-				// Copy the raw details
-				if ev.Details != "" {
-					copyToClipboard(prettyPrintJSONDetail(ev.Details))
+				// Copy the raw event diagnostics.
+				if data := formatWorkflowEventDataRaw(&ev); data != "" {
+					copyToClipboard(data)
 					// Show "Copied!" feedback
 					panel.SetTitle(fmt.Sprintf("%s Copied!", theme.IconCompleted))
 					panel.SetTitleColor(temporal.StatusCompleted.Color())
@@ -1855,7 +1888,7 @@ func (wd *WorkflowDetail) showIOModal() {
 	// Create modal - use percentage-based sizing for larger display
 	modal := components.NewModal(components.ModalConfig{
 		Title:     fmt.Sprintf("%s Input/Output: %s", theme.IconWorkflow, truncateStr(wd.workflow.Type, 30)),
-		Width:     0,  // 0 means use percentage
+		Width:     0, // 0 means use percentage
 		Height:    0,
 		MinWidth:  120,
 		MinHeight: 35,


### PR DESCRIPTION
Added Source and Stack Trace to WorkflowTaskFailure details as used in Temporal Web UI.

Web UI Reference:
<img width="1264" height="751" alt="Screenshot 2026-05-07 at 9 08 05 PM" src="https://github.com/user-attachments/assets/8cd931c9-8bd4-4f00-86f7-2b68524228d6" />

Demo:

https://github.com/user-attachments/assets/5cd8f52f-35e4-4a03-8802-24e444ae5909



